### PR TITLE
Fix destination handling for multiple deploy config files

### DIFF
--- a/pkg/kamal/config.go
+++ b/pkg/kamal/config.go
@@ -17,6 +17,10 @@ type DeployDestination struct {
 }
 
 // FindDeployConfigs discovers config/deploy*.yml and config/deploy*.yaml in the given directory.
+// In Kamal, deploy.yml is the base config and deploy.<destination>.yml files are destination
+// overlays. When destination files exist, only those are returned (deploy.yml is the shared
+// base, not a separate destination). When no destination files exist, deploy.yml is returned
+// as a single entry with an empty destination name.
 func FindDeployConfigs(dir string) ([]DeployDestination, error) {
 	configDir := filepath.Join(dir, "config")
 	fi, err := os.Stat(configDir)
@@ -27,51 +31,89 @@ func FindDeployConfigs(dir string) ([]DeployDestination, error) {
 	if err != nil {
 		return nil, err
 	}
-	var out []DeployDestination
+	var baseConfig *DeployDestination
+	var destinations []DeployDestination
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
 		}
 		name := e.Name()
-		var destName string
+		configPath := filepath.Join(configDir, name)
 		if name == "deploy.yml" || name == "deploy.yaml" {
-			destName = "production"
+			// This is the base config file. Only used as a destination entry
+			// when no destination-specific files exist.
+			data, err := os.ReadFile(configPath)
+			if err != nil {
+				continue
+			}
+			var cfg map[string]interface{}
+			if err := yaml.Unmarshal(data, &cfg); err != nil {
+				continue
+			}
+			service := "default"
+			if s, ok := cfg["service"].(string); ok && s != "" {
+				service = s
+			}
+			baseConfig = &DeployDestination{
+				Name:       "",
+				ConfigPath: configPath,
+				Service:    service,
+				Config:     cfg,
+			}
 		} else if strings.HasPrefix(name, "deploy.") && (strings.HasSuffix(name, ".yml") || strings.HasSuffix(name, ".yaml")) {
 			ext := name[strings.LastIndex(name, "."):]
-			destName = name[7 : len(name)-len(ext)]
-		} else {
-			continue
+			destName := name[7 : len(name)-len(ext)]
+			data, err := os.ReadFile(configPath)
+			if err != nil {
+				continue
+			}
+			var cfg map[string]interface{}
+			if err := yaml.Unmarshal(data, &cfg); err != nil {
+				continue
+			}
+			// For destination files, read service from the base config if not specified
+			// in the destination file, falling back to destination name.
+			service := destName
+			if s, ok := cfg["service"].(string); ok && s != "" {
+				service = s
+			}
+			destinations = append(destinations, DeployDestination{
+				Name:       destName,
+				ConfigPath: configPath,
+				Service:    service,
+				Config:     cfg,
+			})
 		}
-		configPath := filepath.Join(configDir, name)
-		data, err := os.ReadFile(configPath)
-		if err != nil {
-			continue
-		}
-		var cfg map[string]interface{}
-		if err := yaml.Unmarshal(data, &cfg); err != nil {
-			continue
-		}
-		service := destName
-		if s, ok := cfg["service"].(string); ok && s != "" {
-			service = s
-		}
-		out = append(out, DeployDestination{
-			Name:       destName,
-			ConfigPath: configPath,
-			Service:    service,
-			Config:     cfg,
-		})
 	}
-	return out, nil
+	// If destination files exist, return only those.
+	// deploy.yml is the base config shared by all destinations, not a separate target.
+	if len(destinations) > 0 {
+		// Try to fill in service name from base config for destinations that
+		// don't define their own service (common since destination files only
+		// contain overrides).
+		if baseConfig != nil {
+			for i := range destinations {
+				if _, ok := destinations[i].Config["service"].(string); !ok {
+					destinations[i].Service = baseConfig.Service
+				}
+			}
+		}
+		return destinations, nil
+	}
+	// No destination files: deploy.yml is the single target (no -d flag needed).
+	if baseConfig != nil {
+		return []DeployDestination{*baseConfig}, nil
+	}
+	return nil, nil
 }
 
 // SecretsPath returns the path to the secrets file for the given destination.
-// Kamal uses .kamal/secrets by default and .kamal/secrets.<destination> for non-production.
-// For non-production destinations, it returns the destination-specific path regardless of
-// whether the file exists (to support file creation).
+// Kamal uses .kamal/secrets for the base (no destination) and .kamal/secrets-<destination>
+// for named destinations. Returns the destination-specific path regardless of whether
+// the file exists (to support file creation).
 func SecretsPath(dir string, dest *DeployDestination) string {
 	base := filepath.Join(dir, ".kamal", "secrets")
-	if dest != nil && dest.Name != "" && dest.Name != "production" {
+	if dest != nil && dest.Name != "" {
 		return base + "-" + dest.Name
 	}
 	return base

--- a/pkg/kamal/runner.go
+++ b/pkg/kamal/runner.go
@@ -42,7 +42,7 @@ func buildGlobalArgs(opts RunOptions) []string {
 	if opts.ConfigFile != "" {
 		args = append(args, "--config-file", opts.ConfigFile)
 	}
-	if opts.Destination != "" && opts.Destination != "production" {
+	if opts.Destination != "" {
 		args = append(args, "--destination", opts.Destination)
 	}
 	if opts.Primary {
@@ -144,13 +144,12 @@ func RunKamalStream(subcommand []string, opts RunOptions, onLine func(line strin
 }
 
 // RunOpts builds RunOptions from CWD and optional destination.
+// Kamal resolves config files automatically from the working directory,
+// so we only need to pass the -d flag for named destinations.
 func RunOpts(cwd string, dest *DeployDestination) RunOptions {
 	o := RunOptions{Cwd: cwd}
-	if dest != nil {
-		o.ConfigFile = dest.ConfigPath
-		if dest.Name != "production" {
-			o.Destination = dest.Name
-		}
+	if dest != nil && dest.Name != "" {
+		o.Destination = dest.Name
 	}
 	return o
 }
@@ -391,7 +390,11 @@ func ProxyBootConfigReset(opts RunOptions) (Result, error) {
 }
 
 // Label returns a short label for the destination (e.g. "myapp (staging)").
+// For the base config (no destination), returns just the service name.
 func (d *DeployDestination) Label() string {
+	if d.Name == "" {
+		return d.Service
+	}
 	return fmt.Sprintf("%s (%s)", d.Service, d.Name)
 }
 

--- a/pkg/kamal/runner_test.go
+++ b/pkg/kamal/runner_test.go
@@ -31,11 +31,11 @@ func TestBuildGlobalArgs(t *testing.T) {
 			expected: []string{"--destination", "staging"},
 		},
 		{
-			name: "destination (production - should be ignored)",
+			name: "destination (production)",
 			opts: RunOptions{
 				Destination: "production",
 			},
-			expected: nil,
+			expected: []string{"--destination", "production"},
 		},
 		{
 			name: "primary flag",
@@ -218,15 +218,26 @@ func TestRunOpts(t *testing.T) {
 			expectedDest: "",
 		},
 		{
+			name: "base config (no destination)",
+			cwd:  "/project",
+			dest: &DeployDestination{
+				Name:       "",
+				ConfigPath: "/project/config/deploy.yml",
+			},
+			expectedCwd:  "/project",
+			expectedConf: "",
+			expectedDest: "",
+		},
+		{
 			name: "production destination",
 			cwd:  "/project",
 			dest: &DeployDestination{
 				Name:       "production",
-				ConfigPath: "/project/config/deploy.yml",
+				ConfigPath: "/project/config/deploy.production.yml",
 			},
 			expectedCwd:  "/project",
-			expectedConf: "/project/config/deploy.yml",
-			expectedDest: "",
+			expectedConf: "",
+			expectedDest: "production",
 		},
 		{
 			name: "staging destination",
@@ -236,7 +247,7 @@ func TestRunOpts(t *testing.T) {
 				ConfigPath: "/project/config/deploy.staging.yml",
 			},
 			expectedCwd:  "/project",
-			expectedConf: "/project/config/deploy.staging.yml",
+			expectedConf: "",
 			expectedDest: "staging",
 		},
 	}


### PR DESCRIPTION
## Summary

Fixes #1 — Destinations don't work when a project has multiple deploy config files (`deploy.yml`, `deploy.staging.yml`, `deploy.production.yml`).

**Three root causes fixed:**

- **`deploy.yml` treated as "production" destination:** When destination files exist, `deploy.yml` is the shared base config in Kamal, not a separate destination. The old code created duplicate "production" entries (one from `deploy.yml` and one from `deploy.production.yml`). Now only destination-specific files are listed when they exist.

- **Incorrect `--config-file` usage:** The old code passed `--config-file config/deploy.staging.yml` to Kamal, but `--config-file` specifies the *base* config path. Kamal destinations work by automatically merging `deploy.<name>.yml` on top of `deploy.yml` when `-d <name>` is used. Removed the incorrect `--config-file` and rely on Kamal's convention-based file resolution.

- **`--destination production` flag suppressed:** `buildGlobalArgs` had a filter that skipped the `--destination` flag when the destination was "production". This meant `deploy.production.yml` overrides were never applied. Removed this filter so all named destinations get the `-d` flag.

**Additional fixes:**
- `SecretsPath`: "production" destination now correctly maps to `.kamal/secrets-production`
- `Label()`: Base config (no destination) shows just the service name instead of `myapp ()`
- Destination files that don't define a `service` key now inherit it from the base `deploy.yml`

## Test plan

- [x] Updated `TestFindDeployConfigs` — verifies the exact scenario from the issue (3 files → 2 destinations)
- [x] Added `TestFindDeployConfigs_ServiceFromBaseConfig` — verifies service name inheritance
- [x] Updated `TestBuildGlobalArgs` — "production" destination now generates `--destination production`
- [x] Updated `TestRunOpts` — no `--config-file`, correct destination flag for all cases
- [x] Updated `TestSecretsPath` — production gets `secrets-production`
- [x] Added `TestDeployDestination_Label` case for empty name (base config)
- [x] All tests pass, project builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)